### PR TITLE
docs: fix typo in version menu section ('pasge' -> 'page')

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,14 +12,14 @@ jobs:
     name: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: 'pip'
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}

--- a/user-guide/source/tutorial/02-toolbar.rst
+++ b/user-guide/source/tutorial/02-toolbar.rst
@@ -147,7 +147,7 @@ You can perform the following actions:
 
 - **Manage versions...** - get a list of all versions of this page in the sidebar.
 - **Compare to version <x>...** - get a visual comparison on how the currently viewed
-  version differs from any other version of the pasge. Difference are highlighted by
+  version differs from any other version of the page. Difference are highlighted by
   colors either on the page or the page's source code.
 - **Discard Changes** - makes all changes of the current draft undone
 


### PR DESCRIPTION
Corrected a spelling error in the version menu section where "pasge" was mistakenly written instead of "page".